### PR TITLE
java: prevent dragging from resize after release

### DIFF
--- a/java/core/src/main/java/io/github/hey2022/qfield/Main.java
+++ b/java/core/src/main/java/io/github/hey2022/qfield/Main.java
@@ -426,7 +426,7 @@ public class Main extends InputAdapter implements ApplicationListener {
   public boolean touchDragged(int x, int y, int pointer) {
     cursorPos.set(x, y);
     viewport.unproject(cursorPos);
-    if (inputMode == InputMode.CHECKPOINT && !checkpoints.empty()) {
+    if (inputMode == InputMode.CHECKPOINT && !checkpoints.empty() && !checkpoints.peek().enabled) {
       checkpoints.peek().resetRadius(cursorPos);
     }
     return false;


### PR DESCRIPTION
This prevents right click drag to resize a checkpoint after it is already set

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #32 
- <kbd>&nbsp;2&nbsp;</kbd> #33 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #31 
<!-- GitButler Footer Boundary Bottom -->

