### PR TITLE
Change repeater modifier to control

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ In addition to the game, a reinforcement learning (RL) model is planned to be tr
 
 ### Charge mode controls
 
-- (shift) Left click: (repeatedly) Add positive charge.
+- (control) Left click: (repeatedly) Add positive charge.
 - Middle click: Move free charge to cursor.
-- (shift) Right click: (repeatedly) Add negative charge.
-- (shift) X: (repeatedly) Delete selected charge under cursor.
+- (control) Right click: (repeatedly) Add negative charge.
+- (control) X: (repeatedly) Delete selected charge under cursor.
 
 ### Checkpoint mode controls
 
 - Left click: Add checkpoint.
 - Click and drag: Add checkpoint and adjust size.
-- (shift) X: (repeatedly) Delete selected checkpoint under cursor.
+- (control) X: (repeatedly) Delete selected checkpoint under cursor.

--- a/java/core/src/main/java/io/github/hey2022/qfield/Main.java
+++ b/java/core/src/main/java/io/github/hey2022/qfield/Main.java
@@ -292,7 +292,10 @@ public class Main extends InputAdapter implements ApplicationListener {
     if (Gdx.input.isKeyPressed(Input.Keys.EQUALS)) {
       adjustZoom(-1.0f * dt);
     }
-    if (Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT) && isPrep()) {
+    // SHIFT_LEFT is deprecated
+    if ((Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT)
+            || Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT))
+        && isPrep()) {
       if (Gdx.input.isKeyPressed(Input.Keys.X)) {
         delete();
       } else if (inputMode == InputMode.CHARGE && Gdx.input.isTouched()) {


### PR DESCRIPTION
In Firefox, if you hold down the Shift key while right-clicking, then the context menu is shown without the contextmenu event being fired. Therefore, canceling the event does not stop the context menu from being shown.
https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event#canceling_the_contextmenu_event
This prevents the context menu from being blocked when using shift as the modifier.